### PR TITLE
[CustomHelp] fix cog help in minimal theme

### DIFF
--- a/customhelp/themes/minimal.py
+++ b/customhelp/themes/minimal.py
@@ -76,7 +76,7 @@ class MinimalHelp(ThemesMeta):
         coms = await self.get_cog_help_mapping(ctx, obj, help_settings=help_settings)
         if not (coms or help_settings.verify_exists):
             return
-        description = obj.long_desc or ""
+        description = obj.format_help_for_context(ctx) or ""
         tagline = (help_settings.tagline) or self.get_default_tagline(ctx)
         full_text = f"{description}\n\n{tagline}\n\n"
 


### PR DESCRIPTION
This PR fixes Attribute error in minimal theme when trying to fetch help for AnyCog.
For example, `[p]help Core`

```py
[2021-05-26 09:52:26] [ERROR] red: Exception in command: 'help'
Traceback (most recent call last):
  File "/opt/lib/python3.9/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/opt/lib/python3.9/site-packages/redbot/core/commands/help.py", line 868, in red_help
    await ctx.bot.send_help_for(ctx, thing_to_get_help_for, from_help_command=True)
  File "/opt/lib/python3.9/site-packages/redbot/core/bot.py", line 1059, in send_help_for
    return await self._help_formatter.send_help(
  File "/opt/cogs/CogManager/cogs/customhelp/core/base_help.py", line 147, in send_help
    await self.format_cog_help(ctx, help_for, help_settings=help_settings)
  File "/opt/cogs/CogManager/cogs/customhelp/themes/minimal.py", line 79, in format_cog_help
    description = obj.long_desc or ""
AttributeError: 'Core' object has no attribute 'long_desc'
```

This PR addresses and fixes the error. Lemme know what you think!