### PR TITLE
[customhelp] button help menus

### DIFF
--- a/customhelp/core/__init__.py
+++ b/customhelp/core/__init__.py
@@ -1,6 +1,6 @@
-from discord import __version__
+from discord import __version__ as dpy_version
 
-from .dpy_menus import NoReplyMenus, ReplyMenus
+from .dpy_menus import NoReplyMenus, ReplyMenus, get_button_menu
 
 # Keeping all global vars in one place
 GLOBAL_CATEGORIES = []
@@ -9,16 +9,22 @@ ARROWS = {}
 __BaseMenu = None
 
 
-def set_menu(reply: bool):
+def set_menu(*, replies: bool, buttons: bool):
     global __BaseMenu
-    if reply:
-        if __version__ <= "1.5.0":
-            return "You need to have Dpy version 1.6.0 or greater to use replies", 0
+    if replies:
+        if dpy_version <= "1.5.0":
+            return "You need to have discord.py version 1.6.0 or greater to use replies.", False
         __BaseMenu = ReplyMenus
-        return "Sucessfully enabled replies for help menus", 1
+        return "Enabled replies for help menus.", True
+    elif buttons:
+        try:
+            __BaseMenu = get_button_menu()
+        except RuntimeError as error:
+            return str(error), 0
+        return "Enabled buttons for help menus.", True
     else:
         __BaseMenu = NoReplyMenus
-        return "Sucessfully disabled replies for help menus", 1
+        return "Reset the help menu to vanilla.", True
 
 
 # wew thanks jack

--- a/customhelp/core/__init__.py
+++ b/customhelp/core/__init__.py
@@ -6,10 +6,11 @@ from .dpy_menus import NoReplyMenus, ReplyMenus, get_button_menu
 GLOBAL_CATEGORIES = []
 ARROWS = {}
 
-__BaseMenu = None
+__BaseMenu = ReplyMenus
+use_buttons = False
 
 
-def set_menu(*, replies: bool, buttons: bool):
+def set_menu(*, replies: bool, buttons: bool, validate_buttons: bool = False):
     global __BaseMenu
     if replies:
         if dpy_version <= "1.5.0":
@@ -17,10 +18,13 @@ def set_menu(*, replies: bool, buttons: bool):
         __BaseMenu = ReplyMenus
         return "Enabled replies for help menus.", True
     elif buttons:
-        try:
-            __BaseMenu = get_button_menu()
-        except RuntimeError as error:
-            return str(error), 0
+        if validate_buttons:
+            try:
+                __BaseMenu = get_button_menu()
+            except RuntimeError as error:
+                return str(error), 0
+        global use_buttons
+        use_buttons = True
         return "Enabled buttons for help menus.", True
     else:
         __BaseMenu = NoReplyMenus
@@ -29,4 +33,11 @@ def set_menu(*, replies: bool, buttons: bool):
 
 # wew thanks jack
 def get_menu():
+    global __BaseMenu
+    global use_buttons
+    if use_buttons:
+        try:
+            __BaseMenu = get_button_menu()
+        except RuntimeError:
+            __BaseMenu = ReplyMenus
     return __BaseMenu

--- a/customhelp/core/dpy_menus.py
+++ b/customhelp/core/dpy_menus.py
@@ -45,7 +45,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         # self.cog = cog
         self.page_start = page_start
 
-    async def show_page(self, page_number, payload):
+    async def show_page(self, page_number, payload=None):
         # added unused payload arg since ButtonMenu requires the button to be passed
         # when showing a page with InteractionButton.update
         await super().show_page(page_number)
@@ -56,7 +56,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
     def add_button(self, button, *, react=False, interaction=None):
         return super().add_button(button, react=react)
 
-    async def show_checked_page(self, page_number: int, payload) -> None:
+    async def show_checked_page(self, page_number: int, payload=None):
         max_pages = self._source.get_max_pages()
         try:
             if max_pages is None or page_number < max_pages and page_number >= 0:
@@ -104,13 +104,16 @@ class ReplyMenus(BaseMenu, inherit_buttons=False):
         return kwargs
 
 
-def get_button_menu():
+def get_button_menu(use_replies: bool):
     try:
         from slashtags import BaseButtonMenu
     except ImportError as exc:
         raise RuntimeError("Button menus require the `slashtags` cog to be loaded.") from exc
 
     class HelpButtonMenu(BaseButtonMenu, BaseMenu, inherit_buttons=False):
+        async def send_initial_message(self, ctx, channel: discord.TextChannel):
+            return await super().send_initial_message(ctx, channel, reply=use_replies)
+
         async def show_page(self, page_number, button):
             cls = BaseButtonMenu if button else BaseMenu
             await cls.show_page(self, page_number, button)

--- a/customhelp/core/dpy_menus.py
+++ b/customhelp/core/dpy_menus.py
@@ -22,7 +22,7 @@ class ListPages(menus.ListPageSource):
         return page
 
 
-class ReplyMenus(menus.MenuPages, inherit_buttons=False):
+class BaseMenu(menus.MenuPages, inherit_buttons=False):
     def __init__(
         self,
         source: menus.PageSource,
@@ -45,87 +45,69 @@ class ReplyMenus(menus.MenuPages, inherit_buttons=False):
         # self.cog = cog
         self.page_start = page_start
 
+    async def show_page(self, page_number, payload = None): 
+        # added unused payload arg since ButtonMenu requires the button to be passed
+        # when showing a page with InteractionButton.update
+        page = await self._source.get_page(page_number)
+        self.current_page = page_number
+        kwargs = await self._get_kwargs_from_page(page)
+        await self.message.edit(**kwargs)
+
+
+    async def show_checked_page(self, page_number: int, payload = None) -> None:
+        max_pages = self._source.get_max_pages()
+        try:
+            if max_pages is None or page_number < max_pages and page_number >= 0:
+                # If it doesn't give maximum pages, it cannot be checked
+                await self.show_page(page_number)
+            elif page_number >= max_pages:
+                await self.show_page(0)
+            else:
+                await self.show_page(max_pages - 1)
+        except IndexError:
+            # An error happened that can be handled, so ignore it.
+            pass
+
+    def reaction_check(self, payload):
+        """Just extends the default reaction_check to use owner_ids"""
+        if payload.message_id != self.message.id:
+            return False
+        if payload.user_id not in (*self.bot.owner_ids, self._author_id):
+            return False
+        return payload.emoji in self.buttons
+
+
+NoReplyMenus = BaseMenu
+
+
+class ReplyMenus(BaseMenu, inherit_buttons=False):
     async def send_initial_message(self, ctx, channel):
         page = await self._source.get_page(0)
         kwargs = await self._get_kwargs_from_page(page)
-        return await ctx.reply(**kwargs)
+        kwargs["reference"] = ctx.message.to_reference(fail_if_not_exists=False) # sends message silently when message is deleted
+        return await ctx.send(**kwargs)
 
     async def _get_kwargs_from_page(self, page):
         # Do this if you dont want to ping the user
-        no_ping = {"allowed_mentions": discord.AllowedMentions(replied_user=False)}
+        kwargs = {"allowed_mentions": discord.AllowedMentions(replied_user=False)}
         value = await discord.utils.maybe_coroutine(self._source.format_page, self, page)
         if isinstance(value, dict):
-            no_ping.update(value)
+            kwargs.update(value)
         elif isinstance(value, str):
-            no_ping.update({"content": value})
+            kwargs["content"] = value
         elif isinstance(value, discord.Embed):
-            no_ping.update({"embed": value})
-        return no_ping
+            kwargs["embed"] = value
+        return kwargs
 
-    async def show_checked_page(self, page_number: int) -> None:
-        max_pages = self._source.get_max_pages()
-        try:
-            if max_pages is None or page_number < max_pages and page_number >= 0:
-                # If it doesn't give maximum pages, it cannot be checked
-                await self.show_page(page_number)
-            elif page_number >= max_pages:
-                await self.show_page(0)
-            else:
-                await self.show_page(max_pages - 1)
-        except IndexError:
-            # An error happened that can be handled, so ignore it.
-            pass
+def get_button_menu():
+    try:
+        from slashtags import ButtonMenu
+    except ImportError as exc:
+        raise RuntimeError("Button menus require the `slashtags` cog to be loaded.") from exc
 
-    def reaction_check(self, payload):
-        """Just extends the default reaction_check to use owner_ids"""
-        if payload.message_id != self.message.id:
-            return False
-        if payload.user_id not in (*self.bot.owner_ids, self._author_id):
-            return False
-        return payload.emoji in self.buttons
+    class HelpButtonMenu(ButtonMenu, BaseMenu, inherit_buttons=False):
+        async def show_page(self, page_number, button = None):
+            cls = ButtonMenu if button else BaseMenu
+            await cls.show_page(self, page_number, button)
 
-
-class NoReplyMenus(menus.MenuPages, inherit_buttons=False):
-    def __init__(
-        self,
-        source: menus.PageSource,
-        # cog: commands.Cog,
-        clear_reactions_after: bool = True,
-        delete_message_after: bool = False,
-        timeout: int = 60,
-        message: discord.Message = None,
-        page_start: int = 0,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(
-            source,
-            clear_reactions_after=clear_reactions_after,
-            delete_message_after=delete_message_after,
-            timeout=timeout,
-            message=message,
-            **kwargs,
-        )
-        # self.cog = cog
-        self.page_start = page_start
-
-    async def show_checked_page(self, page_number: int) -> None:
-        max_pages = self._source.get_max_pages()
-        try:
-            if max_pages is None or page_number < max_pages and page_number >= 0:
-                # If it doesn't give maximum pages, it cannot be checked
-                await self.show_page(page_number)
-            elif page_number >= max_pages:
-                await self.show_page(0)
-            else:
-                await self.show_page(max_pages - 1)
-        except IndexError:
-            # An error happened that can be handled, so ignore it.
-            pass
-
-    def reaction_check(self, payload):
-        """Just extends the default reaction_check to use owner_ids"""
-        if payload.message_id != self.message.id:
-            return False
-        if payload.user_id not in (*self.bot.owner_ids, self._author_id):
-            return False
-        return payload.emoji in self.buttons
+    return HelpButtonMenu

--- a/customhelp/core/utils.py
+++ b/customhelp/core/utils.py
@@ -104,15 +104,19 @@ async def react_page(ctx, emoji, help_settings, bypass_checks=False):
     if pages:
 
         async def action(menu, payload):
-            await menu.change_source(ListPages(pages))
+            await menu.change_source(ListPages(pages), payload)
             if len(pages) == 1:
                 # If any one button is present, disable it's functionality cause its a 1 page menu.
                 if ARROWS["left"] in map(str, menu._buttons.keys()):
                     menu.add_button(empty_button(ARROWS["left"]))
                     menu.add_button(empty_button(ARROWS["right"]))
             else:
-                asyncio.create_task(menu.add_button(prev_page(ARROWS["left"]), react=True))
-                asyncio.create_task(menu.add_button(next_page(ARROWS["right"]), react=True))
+                asyncio.create_task(
+                    menu.add_button(prev_page(ARROWS["left"]), react=True, interaction=payload)
+                )
+                asyncio.create_task(
+                    menu.add_button(next_page(ARROWS["right"]), react=True, interaction=payload)
+                )
 
         return menus.Button(emoji, action)
     else:
@@ -124,7 +128,7 @@ async def home_page(ctx, emoji, help_settings):
     if pages:
 
         async def action(menu, payload):
-            await menu.change_source(ListPages(pages))
+            await menu.change_source(ListPages(pages), payload)
             if len(pages) == 1 and ARROWS["left"] in map(str, menu._buttons.keys()):
                 menu.add_button(empty_button(ARROWS["left"]))
                 menu.add_button(empty_button(ARROWS["right"]))

--- a/customhelp/core/utils.py
+++ b/customhelp/core/utils.py
@@ -137,7 +137,7 @@ async def home_page(ctx, emoji, help_settings):
 def first_page(emoji):
     async def go_to_first_page(self, payload):
         """go to the first page"""
-        await self.show_page(0)
+        await self.show_page(0, payload)
 
     return menus.Button(
         emoji, go_to_first_page, position=menus.First(), skip_if=_skip_double_triangle_buttons
@@ -147,7 +147,7 @@ def first_page(emoji):
 def last_page(emoji):
     async def go_to_last_page(self, payload):
         """go to the last page"""
-        await self.show_page(self._source.get_max_pages() - 1)
+        await self.show_page(self._source.get_max_pages() - 1, payload)
 
     return menus.Button(emoji, go_to_last_page, skip_if=_skip_double_triangle_buttons)
 
@@ -155,7 +155,7 @@ def last_page(emoji):
 def prev_page(emoji):
     async def go_to_previous_page(self, payload):
         """go to the previous page"""
-        await self.show_checked_page(self.current_page - 1)
+        await self.show_checked_page(self.current_page - 1, payload)
 
     return menus.Button(emoji, go_to_previous_page, skip_if=_skip_single_arrows)
 
@@ -163,7 +163,7 @@ def prev_page(emoji):
 def next_page(emoji):
     async def go_to_next_page(self, payload):
         """go to the next page"""
-        await self.show_checked_page(self.current_page + 1)
+        await self.show_checked_page(self.current_page + 1, payload)
 
     return menus.Button(emoji, go_to_next_page, skip_if=_skip_single_arrows)
 

--- a/customhelp/customhelp.py
+++ b/customhelp/customhelp.py
@@ -37,7 +37,7 @@ Config Structure:
       "categories":
       [
             {
-                "name" : name 
+                "name" : name
                 "desc" : desc
                 "long_desc":longer description
                 "cogs" : []
@@ -246,6 +246,7 @@ class CustomHelp(commands.Cog):
             "thumbnail": "thumbnail",
             "timeout": "Timeout(secs)",
             "replies": "Use replies",
+            "buttons": "Use buttons",
         }
         other_settings = []
         # url doesnt exist now, that's why the check. sorry guys.
@@ -781,19 +782,17 @@ class CustomHelp(commands.Cog):
     @settings.command(aliases=["usereplies", "reply"])
     async def usereply(self, ctx, option: bool):
         """Enable/Disable help menus to use replies"""
-        response, setting = set_menu(replies=option, buttons=False)
-        if setting:
+        response, success = set_menu(replies=option, buttons=None)
+        if success:
             await self.config.settings.replies.set(option)
-            await self.config.settings.buttons.set(not option)
         await ctx.send(response)
 
     @settings.command(aliases=["buttons"])
     async def usebuttons(self, ctx, option: bool):
         """Enable/disable button menus."""
-        response, setting = set_menu(replies=False, buttons=option)
-        if setting:
+        response, success = set_menu(replies=None, buttons=option)
+        if success:
             await self.config.settings.buttons.set(option)
-            await self.config.settings.replies.set(not option)
         await ctx.send(response)
 
     @settings.command()

--- a/customhelp/customhelp.py
+++ b/customhelp/customhelp.py
@@ -84,6 +84,7 @@ class CustomHelp(commands.Cog):
                 "thumbnail": None,
                 "timeout": 120,
                 "replies": True,
+                "buttons": False,
                 "arrows": {
                     "right": "\N{BLACK RIGHTWARDS ARROW}\N{VARIATION SELECTOR-16}",
                     "left": "\N{LEFTWARDS BLACK ARROW}\N{VARIATION SELECTOR-16}",
@@ -154,7 +155,7 @@ class CustomHelp(commands.Cog):
         await self.refresh_arrows()
 
         settings = await self.config.settings()
-        set_menu(settings["replies"])
+        set_menu(replies=settings["replies"], buttons=settings.get("buttons", False))
         if not settings["set_formatter"]:
             return
         main_theme = BaguetteHelp(self.bot, self.config)
@@ -780,10 +781,20 @@ class CustomHelp(commands.Cog):
     @settings.command(aliases=["usereplies", "reply"])
     async def usereply(self, ctx, option: bool):
         """Enable/Disable help menus to use replies"""
-        res = set_menu(option)
-        if res[1]:
+        response, setting = set_menu(replies=option, buttons=False)
+        if setting:
             await self.config.settings.replies.set(option)
-        await ctx.send(res[0])
+            await self.config.settings.buttons.set(not option)
+        await ctx.send(response)
+
+    @settings.command(aliases=["buttons"])
+    async def usebuttons(self, ctx, option: bool):
+        """Enable/disable button menus."""
+        response, setting = set_menu(replies=False, buttons=option)
+        if setting:
+            await self.config.settings.buttons.set(option)
+            await self.config.settings.replies.set(not option)
+        await ctx.send(response)
 
     @settings.command()
     async def timeout(self, ctx, wait: int):


### PR DESCRIPTION
Adds support for button help menus, requiring the very latest version of slashtags to be loaded.

This has been mostly tested but there may be some bugs that haven't been found yet.