### PR TITLE
[Google] Remove first 3 images instead of 2

### DIFF
--- a/google/google.py
+++ b/google/google.py
@@ -450,5 +450,5 @@ class Google(Yandex, commands.Cog):
         return final, kwargs
 
     def parser_image(self, html):
-        # first 2 are google static logo images
-        return self.link_regex.findall(html)[2:], {}
+        # first 3 are google static logo images
+        return self.link_regex.findall(html)[3:], {}


### PR DESCRIPTION
Google logos like this keep appearing as the first result
![img](https://www.google.com/logos/doodles/2021/doodle-champion-island-games-september-05-6753651837109292-s.png)