### PR TITLE
[customhelp] fix when `aliases` can be a tuple

### DIFF
--- a/customhelp/core/utils.py
+++ b/customhelp/core/utils.py
@@ -74,7 +74,7 @@ def get_cooldowns(command):
 
 # Add aliases
 def get_aliases(command, original):
-    if alias := command.aliases:
+    if alias := list(command.aliases):
         if original in alias:
             alias.remove(original)
             alias.append(command.name)


### PR DESCRIPTION
```py
[2021-10-07 11:16:23] [ERROR] red: Error in command: 'aaaaa'
Traceback (most recent call last):
  File "/opt/env/lib/python3.9/site-packages/discord/ext/commands/core.py", line 167, in wrapped
    ret = await coro(*args, **kwargs)
  File "/data/cogs/CogManager/cogs/aaaaa/aaaaa.py", line 13, in aaaaa
    await ctx.send_help()
  File "/opt/env/lib/python3.9/site-packages/redbot/core/commands/context.py", line 100, in send_help
    await self.bot.send_help_for(self, command)
  File "/opt/env/lib/python3.9/site-packages/redbot/core/bot.py", line 1214, in send_help_for
    return await self._help_formatter.send_help(
  File "/data/cogs/CogManager/cogs/customhelp/core/base_help.py", line 153, in send_help
    await self.format_command_help(ctx, help_for, help_settings=help_settings)
  File "/data/cogs/CogManager/cogs/customhelp/core/base_help.py", line 270, in format_command_help
    if alias := get_aliases(command, ctx.invoked_with):
  File "/data/cogs/CogManager/cogs/customhelp/core/utils.py", line 79, in get_aliases
    alias.remove(original)
AttributeError: 'tuple' object has no attribute 'remove'
```

This only errors if command has aliases of type tuple and relies on `ctx.send_help()` btw.