### PR TITLE
[CustomHelp] Documentation Spelling and Grammar Fixes - and Addition

### DIFF
--- a/docs/source/customhelp.rst
+++ b/docs/source/customhelp.rst
@@ -105,14 +105,14 @@ Category Configuration
 1. | ``[p]chelp dev``
    | This will hide categories and only be visible by the bot owner.
    
-2. |``[p]chelp nsfw``
+2. | ``[p]chelp nsfw``
    | This will hide categories to only be visible within NSFW-marked channels.
    
-3. |``[p]chelp auto``
+3. | ``[p]chelp auto``
    | To make a pre-formatted list of categories, this will take tags from your installed cogs
    | and auto-generate a list for you to use in ``[p]chelp create``.
    
-4. |``[p]chelp info``
+4. | ``[p]chelp info``
    | This will provide a description of themes available.
 
 Custom Help Settings


### PR DESCRIPTION
## Doc Overhaul

I'm doing a little bit of an overhaul of the documentation to fix some grammar and spelling to make a little more sense in English. I've also noticed the lack of stuff for `chelp settings` stuff other than the small notion for custom navigation icons, so I'll be writing those up, while keeping a little to the style of the original as much as I can. (course... I dunno how well I'll keep that XD)

### Todo

- [x] - Grammar
- [x] - Spelling
- [x] - `chelp settings`
- [x] - Final Check