### PR TITLE
[CustomHelp] Ability to delete the command made by the user.

### DIFF
--- a/customhelp/core/base_help.py
+++ b/customhelp/core/base_help.py
@@ -125,9 +125,6 @@ class BaguetteHelp(commands.RedHelpFormatter):
         """
 
         help_settings = await HelpSettings.from_context(ctx)
-        
-        if ctx.channel.permissions_for(ctx.me).manage_messages and await self.config.settings.deletemessage():
-                    await ctx.message.delete()
 
         if help_for is None or isinstance(help_for, dpy_commands.bot.BotBase):
             await self.format_bot_help(ctx, help_settings=help_settings)
@@ -424,6 +421,9 @@ class BaguetteHelp(commands.RedHelpFormatter):
 
         # save on config calls
         channel_permissions = ctx.channel.permissions_for(ctx.me)
+
+        if channel_permissions.manage_messages and await self.config.settings.deletemessage():
+            await ctx.message.delete()
 
         if not (channel_permissions.add_reactions and help_settings.use_menus):
 

--- a/customhelp/customhelp.py
+++ b/customhelp/customhelp.py
@@ -822,10 +822,10 @@ class CustomHelp(commands.Cog):
 
     @settings.command(aliases=["deleteusermessage"])
     async def deletemessage(self, ctx, toggle: bool):
-        """Delete the message that started the help menu."""
-        async with self.config.settings() as f:
-            f["deletemessage"] = toggle
-        await ctx.tick()
+        """Delete the user message that started the help menu.
+        Note: This only works if the bot has permissions to delete the user message, otherwise it's supressed"""
+        await self.config.settings.deletemessage.set(toggle)
+        await ctx.send(f"Sucessfully set delete user toggle to {toggle}")
 
     @settings.command(aliases=["arrow"])
     async def arrows(self, ctx, *, correct_txt=None):


### PR DESCRIPTION
Hello,
Here is the code allowing the bot to delete the message that called the help menu.
This feature is disabled by default and can be enabled by the bot owner with the command "[p]chelp settings deletemessage 1".
Thanks in advance and have a nice day.