### PR TITLE
[CustomHelp] d.py2 async changes

### DIFF
--- a/customhelp/__init__.py
+++ b/customhelp/__init__.py
@@ -11,6 +11,6 @@ with open(Path(__file__).parent / "info.json") as fp:
 
 async def setup(bot: Red) -> None:
     cog = CustomHelp(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     # is this too costly? should I use a task rather?
     await cog._setup()

--- a/customhelp/customhelp.py
+++ b/customhelp/customhelp.py
@@ -109,8 +109,8 @@ class CustomHelp(commands.Cog):
         }
         self.config.register_global(**self.chelp_global)
 
-    def cog_unload(self):
-        self.bot.reset_help_formatter()
+    async def cog_unload(self):
+        await self.bot.reset_help_formatter()
 
     def format_help_for_context(self, ctx: commands.Context) -> str:
         """


### PR DESCRIPTION
Did some testing because d.py2 has async on cog loading and unloading and stuff like that. This PR will address those changes for the latest dpy2_unstable of Red and allow the cog to be used again if it was broken before.

Only did the `customhelp` cog, since I imagine that's going to be the most widely used cog, along with myself. lol