### PR TITLE
Twin theme reaction bug fix

### DIFF
--- a/customhelp/themes/twin.py
+++ b/customhelp/themes/twin.py
@@ -17,7 +17,7 @@ class TwinHelp(ThemesMeta):
                     cog_names = "`" + "` `".join(cat.cogs) + "`" if cat.cogs else ""
                     for i, page in enumerate(pagify(cog_names, page_length=1000, shorten_by=0)):
                         if i == 0:
-                            title = (str(cat.reaction) or "") + f"  __{cat.name.capitalize()}:__ "
+                            title = (cat.reaction and str(cat.reaction) or "") + f"  __{cat.name.capitalize()}:__ "
                         else:
                             title = EMPTY_STRING
                         emb["fields"].append(EmbedField(title, cog_names, False))


### PR DESCRIPTION
It'll fix a bug when there's no reaction for a category following happens:
![image](https://user-images.githubusercontent.com/22246989/168480125-06e74f6e-3068-425e-b431-bee32928b67e.png)

Fixed:
![image](https://user-images.githubusercontent.com/22246989/168480145-4ec73e41-67e3-42a9-85e4-ba8ef0e442f8.png)
