### PR TITLE
Target renamed main branch for precommit workflow

### DIFF
--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -2,9 +2,9 @@ name: Run pre-commit
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   run_precommit:


### PR DESCRIPTION
Looks like this was missed when your main branch was renamed from `master`, which might be why the syntax error from a previous PR was missed.