### PR TITLE
[CustomHelp] Fixed an error when the original message has been deleted.

### DIFF
--- a/customhelp/core/views.py
+++ b/customhelp/core/views.py
@@ -125,7 +125,7 @@ class BaseInteractionMenu(discord.ui.View):
                     **self._get_kwargs_from_page(self.hmenu.pages[0]),
                     view=self,
                     mention_author=False,
-                    reference=message.to_reference(
+                    reference=ctx.message.to_reference(
                         fail_if_not_exists=False
                     ),
                 )

--- a/customhelp/core/views.py
+++ b/customhelp/core/views.py
@@ -121,10 +121,13 @@ class BaseInteractionMenu(discord.ui.View):
     ):
         if message is None:
             if self.hmenu.settings["replies"]:
-                self.message = await ctx.reply(
+                self.message = await ctx.send(
                     **self._get_kwargs_from_page(self.hmenu.pages[0]),
                     view=self,
                     mention_author=False,
+                    reference=message.to_reference(
+                        fail_if_not_exists=False
+                    ),
                 )
             else:
                 self.message = await ctx.send(


### PR DESCRIPTION
Hello,

This error has been obtained with and reported for various cogs:
```
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/data/starship_main/cogs/CogManager/cogs/say/say.py", line 152, in _saydelete
    await self.say(ctx, channel, text, files)
  File "/home/ubuntu/data/starship_main/cogs/CogManager/cogs/say/say.py", line 54, in say
    await ctx.send_help()
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/redbot/core/commands/context.py", line 98, in send_help
    await self.bot.send_help_for(self, command)
...
  File "/home/ubuntu/data/starship_main/cogs/CogManager/cogs/customhelp/core/views.py", line 124, in start
    self.message = await ctx.reply(
                   ^^^^^^^^^^^^^^^^
...
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In message_reference: Unknown message
```
> https://github.com/npc203/npc-cogs/blob/dpy2/customhelp/core/views.py#L124-L128
The help menu is not sent if the original message/command is deleted because Discord cannot find the reference. `

Thanks in advance,
Have a nice day,
AAA3A