### PR TITLE
[CustomHelp] remove ‎U+200E character

### DIFF
--- a/customhelp/customhelp.py
+++ b/customhelp/customhelp.py
@@ -161,7 +161,7 @@ class CustomHelp(commands.Cog):
             # Doesn't work cause force_registration=True
             # uncat_conf = await self.config.uncategorised()
             uncat_obj = Category(
-                name="uncategorised‎", desc="Miscellaneous cogs", cogs=[], is_uncat=True
+                name="uncategorised", desc="Miscellaneous cogs", cogs=[], is_uncat=True
             )
             async with self.config.categories() as conf_cat:
                 conf_cat.append(uncat_obj.to_dict())


### PR DESCRIPTION
U+200E sitting besides "uncategorised" was preventing users from executing [p]help uncategorised
before: `"uncategorised(U+200E)"`
after: `"uncategorised"`
