### PR TITLE
Fix emoji_converter returning the wrong type

### DIFF
--- a/customhelp/core/utils.py
+++ b/customhelp/core/utils.py
@@ -17,7 +17,8 @@ def emoji_converter(bot, emoji) -> Optional[str]:
     if not emoji:
         return
     if isinstance(emoji, int) or emoji.isdigit():
-        return bot.get_emoji(int(emoji))
+        emoji = bot.get_emoji(int(emoji))
+        return str(emoji) if emoji is not None else None
     emoji = emoji.strip()
     return emoji
 


### PR DESCRIPTION
`emoji_converter` sometimes returned instances of `discord.Emoji` rather than `str`s, causing a serialization error on attempting to save it to config.